### PR TITLE
CGLT 84: Journal Entries in Loan Provisioning data

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/accounting/provisioning/data/LoanData.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/accounting/provisioning/data/LoanData.java
@@ -1,0 +1,41 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.accounting.provisioning.data;
+
+import lombok.Getter;
+
+import java.math.BigDecimal;
+
+
+@Getter
+public class LoanData {
+
+    private final Long id;
+    private final String accountNo;
+    private final BigDecimal outstandingBalance;
+
+    private final BigDecimal provisioningAmount;
+
+    public LoanData(Long id, String accountNo, BigDecimal outstandingBalance, BigDecimal provisioningAmount) {
+        this.id = id;
+        this.accountNo = accountNo;
+        this.outstandingBalance = outstandingBalance;
+        this.provisioningAmount = provisioningAmount;
+    }
+}

--- a/fineract-provider/src/main/java/org/apache/fineract/accounting/provisioning/data/LoanProductProvisioningEntryData.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/accounting/provisioning/data/LoanProductProvisioningEntryData.java
@@ -18,8 +18,10 @@
  */
 package org.apache.fineract.accounting.provisioning.data;
 
-import java.math.BigDecimal;
 import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.util.List;
 
 @Getter
 public class LoanProductProvisioningEntryData {
@@ -43,10 +45,13 @@ public class LoanProductProvisioningEntryData {
     private final String expenseAccountCode;
     private final String expenseAccountName;
     private final Long criteriaId;
+    private final Long loanId;
+
+    private final List<LoanData> loans;
 
     public LoanProductProvisioningEntryData(final Long historyId, final Long officeId, final String currencyCode, final Long productId,
             final Long categoryId, final Long overdueInDays, final BigDecimal percentage, final BigDecimal balance, Long liablityAccount,
-            Long expenseAccount, final Long criteriaId) {
+            Long expenseAccount, final Long criteriaId, final Long loanId) {
         this.historyId = historyId;
         this.officeId = officeId;
         this.currencyCode = currencyCode;
@@ -66,12 +71,15 @@ public class LoanProductProvisioningEntryData {
         this.expenseAccountCode = null;
         this.expenseAccountName = null;
         this.criteriaId = criteriaId;
+        this.loanId = loanId;
+        this.loans = null;
+
     }
 
     public LoanProductProvisioningEntryData(final Long historyId, final Long officeId, final String officeName, final String currencyCode,
             final Long productId, final String productName, final Long categoryId, final String categoryName, final Long overdueInDays,
             final BigDecimal amountreserved, Long liablityAccount, String liabilityAccountglCode, String liabilityAccountName,
-            Long expenseAccount, String expenseAccountglCode, String expenseAccountName, final Long criteriaId) {
+            Long expenseAccount, String expenseAccountglCode, String expenseAccountName, final Long criteriaId, final List<LoanData> loans) {
         this.historyId = historyId;
         this.officeId = officeId;
         this.currencyCode = currencyCode;
@@ -91,5 +99,7 @@ public class LoanProductProvisioningEntryData {
         this.expenseAccountCode = expenseAccountglCode;
         this.expenseAccountName = expenseAccountName;
         this.criteriaId = criteriaId;
+        this.loanId = null;
+        this.loans = loans;
     }
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/accounting/provisioning/domain/LoanProductProvisioningEntry.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/accounting/provisioning/domain/LoanProductProvisioningEntry.java
@@ -19,16 +19,21 @@
 package org.apache.fineract.accounting.provisioning.domain;
 
 import java.math.BigDecimal;
+import java.util.HashSet;
 import java.util.Objects;
+import java.util.Set;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.JoinColumn;
+import javax.persistence.JoinTable;
 import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
 import javax.persistence.Table;
 import org.apache.fineract.accounting.glaccount.domain.GLAccount;
 import org.apache.fineract.infrastructure.core.domain.AbstractPersistableCustom;
 import org.apache.fineract.organisation.office.domain.Office;
 import org.apache.fineract.organisation.provisioning.domain.ProvisioningCategory;
+import org.apache.fineract.portfolio.loanaccount.domain.Loan;
 import org.apache.fineract.portfolio.loanproduct.domain.LoanProduct;
 
 @Entity
@@ -71,6 +76,14 @@ public class LoanProductProvisioningEntry extends AbstractPersistableCustom {
     @JoinColumn(name = "expense_account", nullable = false)
     private GLAccount expenseAccount;
 
+    @OneToMany
+    @JoinTable(
+            name = "m_loanproduct_provisioning_entry_loans",  // The name of the join table
+            joinColumns = @JoinColumn(name = "loanproduct_provision_entry_id", referencedColumnName = "id"),
+            inverseJoinColumns = @JoinColumn(name = "loan_id", referencedColumnName = "id")  // Foreign key to Human
+    )
+    private Set<Loan> loan;
+
     protected LoanProductProvisioningEntry() {}
 
     public LoanProductProvisioningEntry(final LoanProduct loanProduct, final Office office, final String currencyCode,
@@ -85,6 +98,8 @@ public class LoanProductProvisioningEntry extends AbstractPersistableCustom {
         this.liabilityAccount = liabilityAccount;
         this.expenseAccount = expenseAccount;
         this.criteriaId = criteriaId;
+        this.loan = new HashSet<>();
+
     }
 
     public void setProvisioningEntry(ProvisioningEntry provisioningEntry) {
@@ -97,6 +112,10 @@ public class LoanProductProvisioningEntry extends AbstractPersistableCustom {
 
     public void addReservedAmount(BigDecimal value) {
         this.reservedAmount = this.reservedAmount.add(value);
+    }
+
+    public void addLoan(Loan loan){
+        this.loan.add(loan);
     }
 
     public Office getOffice() {

--- a/fineract-provider/src/main/java/org/apache/fineract/accounting/provisioning/service/ProvisioningEntriesReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/accounting/provisioning/service/ProvisioningEntriesReadPlatformServiceImpl.java
@@ -194,7 +194,7 @@ public class ProvisioningEntriesReadPlatformServiceImpl implements ProvisioningE
                 BigDecimal outstandingBalance= rs.getBigDecimal("outstandingBalance");
                 BigDecimal provisioningAmount =rs.getBigDecimal("provisioningAmount");
 
-                loans.add(new LoanData(id,accountNo,outstandingBalance,provisioningAmount));
+                loans.add(new LoanData(loanId,accountNo,outstandingBalance,provisioningAmount));
             } while (rs.next() && rs.getInt("id") == id);
 
             return data;

--- a/fineract-provider/src/main/java/org/apache/fineract/accounting/provisioning/service/ProvisioningEntriesWritePlatformServiceJpaRepositoryImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/accounting/provisioning/service/ProvisioningEntriesWritePlatformServiceJpaRepositoryImpl.java
@@ -62,6 +62,8 @@ import org.apache.fineract.organisation.provisioning.data.ProvisioningCriteriaDa
 import org.apache.fineract.organisation.provisioning.domain.ProvisioningCategory;
 import org.apache.fineract.organisation.provisioning.domain.ProvisioningCategoryRepository;
 import org.apache.fineract.organisation.provisioning.service.ProvisioningCriteriaReadPlatformService;
+import org.apache.fineract.portfolio.loanaccount.domain.Loan;
+import org.apache.fineract.portfolio.loanaccount.domain.LoanRepository;
 import org.apache.fineract.portfolio.loanproduct.domain.LoanProduct;
 import org.apache.fineract.portfolio.loanproduct.domain.LoanProductRepository;
 import org.apache.fineract.useradministration.domain.AppUser;
@@ -87,6 +89,7 @@ public class ProvisioningEntriesWritePlatformServiceJpaRepositoryImpl implements
     private final ProvisioningEntriesDefinitionJsonDeserializer fromApiJsonDeserializer;
     private final FromJsonHelper fromApiJsonHelper;
     private final ApplicationEventPublisher eventPublisher;
+    private final LoanRepository loanRepository;
 
     @Override
     public CommandProcessingResult createProvisioningJournalEntries(Long provisioningEntryId, JsonCommand command) {
@@ -227,11 +230,14 @@ public class ProvisioningEntriesWritePlatformServiceJpaRepositoryImpl implements
             LoanProductProvisioningEntry entry = new LoanProductProvisioningEntry(loanProduct, office, data.getCurrencyCode(),
                     provisioningCategory, data.getOverdueInDays(), amountToReserve.getAmount(), liabilityAccount, expenseAccount,
                     criteraId);
+            Loan loan = this.loanRepository.getReferenceById(data.getLoanId());
             entry.setProvisioningEntry(parent);
             if (!provisioningEntries.containsKey(entry.partialHashCode())) {
+                entry.addLoan(loan);
                 provisioningEntries.put(entry.partialHashCode(), entry);
             } else {
                 LoanProductProvisioningEntry entry1 = provisioningEntries.get(entry.partialHashCode());
+                entry1.addLoan(loan);
                 entry1.addReservedAmount(entry.getReservedAmount());
             }
         }

--- a/fineract-provider/src/main/resources/db/changelog/tenant/custom-changelog/CGLT_84_add_loans_to_loan_product_provisional_entries.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/custom-changelog/CGLT_84_add_loans_to_loan_product_provisional_entries.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements. See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership. The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
+    <changeSet id="add_loan_product_provision" author="niceta@inkomoko.com">
+        <createTable tableName="m_loanproduct_provisioning_entry_loans">
+            <column name="loan_id" type="bigint">
+            </column>
+            <column name="loanproduct_provision_entry_id" type="bigint">
+            </column>
+        </createTable>
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
Added Loan Data to Loan Provisioning Data:
Files changed:

- Loan Provisioning Entry Data : Added loan to mapper 
- Loan Product Provisioning Entry: Added a one to many mapping to loans
- ProvisioningEntriesReadPlatformServiceImpl: Modified queries to include loan in creation and fetching 
- ProvisioningEntriesWritePlatformServiceJpaRepositoryImpl: Added loans in provision creation flow

Files Added:
- Loan Data: Used in Loan Provisioning Entry Data
- CGLT_84_add_loans_to_loan_product_provisional_entries.xml: Changelog for additional table mapping loans to provisioning entries