### PR TITLE
CGLT-264 : Command handler entity fix

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/tasks/handler/UpdateTaskCommandHandler.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/tasks/handler/UpdateTaskCommandHandler.java
@@ -28,7 +28,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@CommandType(entity = "STAFF", action = "UPDATE")
+@CommandType(entity = "TASK", action = "UPDATE")
 public class UpdateTaskCommandHandler implements NewCommandSourceHandler {
 
     private final TaskWritePlatformService writePlatformService;


### PR DESCRIPTION
Command handler for task had the wrong entity (STAFF) which was affecting updating staff