### PR TITLE
CGLT-190: Kiva Loan Posting Job Optimisation

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/data/KivaLoanExceptions.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/data/KivaLoanExceptions.java
@@ -1,0 +1,10 @@
+package org.apache.fineract.portfolio.loanaccount.data;
+
+import lombok.Data;
+
+@Data
+public class KivaLoanExceptions {
+
+    private String loanId;
+    private Throwable error;
+}

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/KivaLoanServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/KivaLoanServiceImpl.java
@@ -18,6 +18,8 @@
  */
 package org.apache.fineract.portfolio.loanaccount.service;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -71,6 +73,7 @@ import org.apache.fineract.portfolio.loanaccount.data.KivaLocationData;
 import org.apache.fineract.portfolio.loanaccount.data.KivaSupportedCurrencyData;
 import org.apache.fineract.portfolio.loanaccount.data.KivaSupportedLocationData;
 import org.apache.fineract.portfolio.loanaccount.data.KivaSupportedThemeData;
+import org.apache.fineract.portfolio.loanaccount.data.KivaLoanExceptions;
 import org.apache.fineract.portfolio.loanaccount.data.LoanDetailToKivaData;
 import org.apache.fineract.portfolio.loanaccount.data.ThemeData;
 import org.apache.fineract.portfolio.loanaccount.domain.KivaCurrency;
@@ -128,6 +131,8 @@ public class KivaLoanServiceImpl implements KivaLoanService {
     private static final String KIVA_DEPARTMENT_NOT_FOUND = "Loan Department not supported by kiva";
     private static final String KIVA_SECTOR_ACTIVITY_MISMATCH = "The Sector and Activity are not compatible with Kiva";
 
+    @JsonIgnoreProperties({"stackTrace", "suppressed", "localizedMessage"})
+    static abstract class ThrowableMixin {}
     @Override
     @CronTarget(jobName = JobName.POST_LOAN_ACCOUNTS_TO_KIVA)
     public void postLoanAccountsToKiva() {
@@ -140,6 +145,8 @@ public class KivaLoanServiceImpl implements KivaLoanService {
         notPictured.add(Boolean.TRUE);
 
         List<Loan> loanList = loanRepository.findLoanAccountsToBePostedToKiva();
+
+        ArrayList<KivaLoanExceptions> kivaLoanExceptions = new ArrayList<>();
 
         List<Throwable> exceptions = new ArrayList<>();
 
@@ -156,8 +163,16 @@ public class KivaLoanServiceImpl implements KivaLoanService {
                     loanRepository.saveAndFlush(loan);
                 } catch (Exception e) {
                     log.error("Post Loan to KIVA has failed" + e);
-                    exceptions.add(e);
+                    KivaLoanExceptions kivaLoanException = new KivaLoanExceptions();
+                    kivaLoanException.setError(e);
+                    kivaLoanException.setLoanId(loan.getAccountNumber());
+                    kivaLoanExceptions.add(kivaLoanException);
                 }
+            }
+            if(!CollectionUtils.isEmpty(kivaLoanExceptions)){
+                postKivaExceptions(kivaLoanExceptions);
+                RuntimeException exception = new RuntimeException("There were " + kivaLoanExceptions.size() + " kiva exceptions");
+                exceptions.add(exception);
             }
             if (!CollectionUtils.isEmpty(exceptions)) {
                 try {
@@ -166,6 +181,31 @@ public class KivaLoanServiceImpl implements KivaLoanService {
                     throw new RuntimeException(e);
                 }
             }
+        }
+    }
+
+    private void postKivaExceptions(ArrayList<KivaLoanExceptions> kivaLoanExceptions) {
+
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.addMixIn(Throwable.class, ThrowableMixin.class);
+
+        String json = null;
+        try {
+            json = mapper.writeValueAsString(kivaLoanExceptions);
+
+            OkHttpClient client = new OkHttpClient().newBuilder().build();
+
+            RequestBody body = RequestBody.create(json, MediaType.parse(org.springframework.http.MediaType.APPLICATION_JSON_VALUE));
+            Request request = new Request.Builder()
+                    .url(getConfigProperty("fineract.integrations.kiva.logsUrl"))
+                    .method("POST", body)
+                    .addHeader(FORM_URL_CONTENT_TYPE, org.springframework.http.MediaType.APPLICATION_JSON_VALUE)
+                    .build();
+                Response response = client.newCall(request).execute();
+
+                log.info(response.body().string());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
         }
     }
 
@@ -222,7 +262,6 @@ public class KivaLoanServiceImpl implements KivaLoanService {
             List<Boolean> notPictured, Loan loan) {
 
         Client client = loan.getClient();
-        Long activityId = getActivityId(client);
         String gender = (client.gender() != null) ? client.gender().label().toLowerCase() : "unknown";
         String loanPurpose = (loan.getLoanPurpose() != null) ? loan.getLoanPurpose().label() : "Not Defined";
         String clientKivaId = client.getKivaId();
@@ -254,6 +293,7 @@ public class KivaLoanServiceImpl implements KivaLoanService {
                 LoanEnumerations.interestType(loan.getLoanProductRelatedDetail().getInterestMethod().getValue()).getValue(),
                 loan.getLoanProductRelatedDetail().getAnnualNominalInterestRate().toString());
 
+        Long activityId = getActivityId(client);
         // build final object
         LoanDetailToKivaData loanDetailToKivaData = new LoanDetailToKivaData(activityId, Boolean.TRUE, loan.getCurrencyCode(),
                 loan.getDescription(), DESCRIPTION_LANGUAGE_ID, Date.valueOf(loan.getDisbursementDate()), " ", base64Image,

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/KivaLoanServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/KivaLoanServiceImpl.java
@@ -169,10 +169,15 @@ public class KivaLoanServiceImpl implements KivaLoanService {
                     kivaLoanExceptions.add(kivaLoanException);
                 }
             }
-            if(!CollectionUtils.isEmpty(kivaLoanExceptions)){
-                postKivaExceptions(kivaLoanExceptions);
-                RuntimeException exception = new RuntimeException("There were " + kivaLoanExceptions.size() + " kiva exceptions");
-                exceptions.add(exception);
+            try{
+                if(!CollectionUtils.isEmpty(kivaLoanExceptions)){
+                    postKivaExceptions(kivaLoanExceptions);
+                    RuntimeException exception = new RuntimeException("There were " + kivaLoanExceptions.size() + " kiva exceptions.");
+                    exceptions.add(exception);
+                }}
+            catch (Exception e){
+                log.error("Could not post errors to external service" + e);
+                exceptions.add(e);
             }
             if (!CollectionUtils.isEmpty(exceptions)) {
                 try {
@@ -203,7 +208,7 @@ public class KivaLoanServiceImpl implements KivaLoanService {
                     .build();
                 Response response = client.newCall(request).execute();
 
-                log.info(response.body().string());
+                log.info("External log service response: "+ response.body().string());
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/fineract-provider/src/main/resources/application.properties
+++ b/fineract-provider/src/main/resources/application.properties
@@ -184,6 +184,7 @@ fineract.integrations.kiva.baseUrl=${KIVA_BASE_URL:partner-api-stage.dk1.kiva.or
 fineract.integrations.kiva.apiVersion=${KIVA_API_VERSION:v3}
 fineract.integrations.kiva.partnerCode=${KIVA_PARTNER_CODE:partner}
 fineract.integrations.kiva.partnerId=${KIVA_PARTNER_ID:319}
+fineract.integrations.kiva.logsUrl=${KIVA_LOGS:XXXXXXXXXX}
 
 //Transunion integration
 fineract.integrations.transUnion.crb.rest.authenticationUrl=${TRANSUNION_CRB_REST_AUTHENTICATION_URL:https://secure3.crbafrica.com/duv2/login}


### PR DESCRIPTION

Kiva Loan posting Job does not rerun after failures do to the error log and message being too big for the db to be updated. 
Due to how jobs work, this affected the job automatically working on a daily basis. 
To fix this issue, The Kiva logs are to be posted to another service where they will be monitored loan by loan and the only error saved be the job will be a simple message and if the posting fails. 